### PR TITLE
allowTableOnStandardPages() on outdated tables names

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -10,7 +10,7 @@ if (!defined('TYPO3_MODE')) {
 );
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript', 'Download Center');
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_pitsdownloadcenter_domain_model_download_category');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_pitsdownloadcenter_domain_model_category');
 $GLOBALS['TCA']['tx_pitsdownloadcenter_domain_model_category'] = array(
 	'ctrl' => array(
 		'title'	=> 'LLL:EXT:pits_downloadcenter/Resources/Private/Language/locallang_db.xlf:tx_pitsdownloadcenter_domain_model_download_category',
@@ -37,7 +37,7 @@ $GLOBALS['TCA']['tx_pitsdownloadcenter_domain_model_category'] = array(
 		'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY) . 'Resources/Public/Icons/tx_pitsdownloadcenter_domain_model_download.gif'
 	),
 );
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_pitsdownloadcenter_domain_model_download_filetype');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_pitsdownloadcenter_domain_model_filetype');
 $GLOBALS['TCA']['tx_pitsdownloadcenter_domain_model_filetype'] = array(
 	'ctrl' => array(
 		'title'	=> 'LLL:EXT:pits_downloadcenter/Resources/Private/Language/locallang_db.xlf:tx_pitsdownloadcenter_domain_model_download_filetype',


### PR DESCRIPTION
The tables problably have undergone a renaming. There is a part  "_download", which is obsolete. I did not check for all occurences. I just followed the behaviour categories can only be created on sys_folder pages. That is the standard.