### PR TITLE
Category root uid

### DIFF
--- a/Classes/Controller/DownloadController.php
+++ b/Classes/Controller/DownloadController.php
@@ -46,7 +46,7 @@ class DownloadController extends AbstractController {
         $transilations = $this->getPageTranslations();
         $filetypesObject = $this->filetypeRepository->findAll();
         $fileTypes = $this->getFileTypes( $filetypesObject );
-        $categoryTree = $this->doGetSubCategories(0);
+
         $storageuid = $this->settings['fileStorage'];
         $storageRepository = $this->storageRepository->findByUid($storageuid);
         if( $storageRepository instanceof \TYPO3\CMS\Core\Resource\ResourceStorage )
@@ -101,7 +101,10 @@ class DownloadController extends AbstractController {
         $transilations = $this->getPageTranslations();
         $filetypesObject = $this->filetypeRepository->findAll();
         $fileTypes = $this->getFileTypes( $filetypesObject );
-        $categoryTree = $this->doGetSubCategories(0);
+        
+        $catTreeRootUid = $this->settings['categoryTreeRootUID'] ? : 0;
+        $categoryTree   = $this->doGetSubCategories($catTreeRootUid);
+        
         $storageuid = $this->settings['fileStorage'];
         $showPreview = ($config['showthumbnail'] == 1)?TRUE:FALSE;
         $storageRepository = $this->storageRepository->findByUid( $storageuid );

--- a/Configuration/TCA/Category.php
+++ b/Configuration/TCA/Category.php
@@ -75,7 +75,7 @@ $GLOBALS['TCA']['tx_pitsdownloadcenter_domain_model_category'] = array(
 				'renderMode' => 'tree',
 				'renderType' => 'selectTree',
 				'foreign_table' => 'tx_pitsdownloadcenter_domain_model_category',
-				'foreign_table_where' => ' AND tx_pitsdownloadcenter_domain_model_category.sys_language_uid IN (-1,0) ORDER BY tx_pitsdownloadcenter_domain_model_category.sorting ASC',
+				'foreign_table_where' => 'AND tx_pitsdownloadcenter_domain_model_category.pid=###CURRENT_PID### AND tx_pitsdownloadcenter_domain_model_category.sys_language_uid IN (-1,0) ORDER BY tx_pitsdownloadcenter_domain_model_category.sorting ASC',
 				'treeConfig' => array(
 					'parentField' => 'parentcategory',
 					'appearance' => array(

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -15,6 +15,8 @@ plugin.tx_pitsdownloadcenter {
 		storagePid =
 	}
 	settings{
-		showFileIconPreview = 1	
+		showFileIconPreview = 1
+		# cat=plugin.tx_pitsdownloadcenter//a; type=int; label=Category tree root PID
+        	categoryTreeRootUID =
 	}
 }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -14,6 +14,7 @@ plugin.tx_pitsdownloadcenter {
 	}
 	settings{
 		showFileIconPreview = {$plugin.tx_pitsdownloadcenter.settings.showFileIconPreview}		
+		categoryTreeRootUID = {$plugin.tx_pitsdownloadcenter.settings.categoryTreeRootUID}
 	}
 }
 

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -10,7 +10,7 @@ if (!defined('TYPO3_MODE')) {
 );
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript', 'Download Center');
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_pitsdownloadcenter_domain_model_download_category');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_pitsdownloadcenter_domain_model_category');
 $GLOBALS['TCA']['tx_pitsdownloadcenter_domain_model_category'] = array(
 	'ctrl' => array(
 		'title'	=> 'LLL:EXT:pits_downloadcenter/Resources/Private/Language/locallang_db.xlf:tx_pitsdownloadcenter_domain_model_download_category',
@@ -37,7 +37,7 @@ $GLOBALS['TCA']['tx_pitsdownloadcenter_domain_model_category'] = array(
 		'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY) . 'Resources/Public/Icons/tx_pitsdownloadcenter_domain_model_download.gif'
 	),
 );
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_pitsdownloadcenter_domain_model_download_filetype');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_pitsdownloadcenter_domain_model_filetype');
 $GLOBALS['TCA']['tx_pitsdownloadcenter_domain_model_filetype'] = array(
 	'ctrl' => array(
 		'title'	=> 'LLL:EXT:pits_downloadcenter/Resources/Private/Language/locallang_db.xlf:tx_pitsdownloadcenter_domain_model_download_filetype',


### PR DESCRIPTION
Hi,
separating categories by PID does not really to it. The Media management (sys_file_metadata) in 6.2 does not separate the categories. Another approach is to have several category trees and mount the instances on different the specific tree roots. 

Again I was not able to branch correctly and separated the commits. ...
